### PR TITLE
Add local development environment using docker-compose 

### DIFF
--- a/actions.php
+++ b/actions.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 require_once "../configure.php";
-$conn = mysql_connect("localhost", $DBuser, $DBpassword);
+$conn = mysql_connect($DBserver, $DBuser, $DBpassword);
 mysql_select_db($DBname, $conn);
   
 $action = mysql_real_escape_string($_GET['action']);

--- a/conf/Dockerfile.db
+++ b/conf/Dockerfile.db
@@ -1,0 +1,4 @@
+FROM mysql:5.5.49
+
+COPY tables.sql /docker-entrypoint-initdb.d/
+COPY users.sql /docker-entrypoint-initdb.d/

--- a/conf/Dockerfile.web
+++ b/conf/Dockerfile.web
@@ -1,0 +1,4 @@
+FROM php:5.6-apache
+
+RUN docker-php-ext-install mysql mysqli pdo pdo_mysql
+COPY conf/configure.docker.php /var/www/configure.php

--- a/conf/configure.docker.php
+++ b/conf/configure.docker.php
@@ -1,0 +1,6 @@
+<?php
+$DBserver = "db";
+$DBname = "wlm";
+$DBuser = "dbuser";
+$DBpassword = "password";
+$loginPw = "pass";

--- a/conf/tables.sql
+++ b/conf/tables.sql
@@ -1,7 +1,8 @@
 CREATE TABLE users (
-  user_name varchar(255) binary NOT NULL default '',
+  name varchar(255) binary NOT NULL default '',
   country varchar(255) binary NOT NULL default ''
 );
+
 CREATE TABLE batches (
   number int unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT,
   country varchar(255) binary NOT NULL default '',

--- a/conf/users.sql
+++ b/conf/users.sql
@@ -1,0 +1,2 @@
+INSERT INTO `users`(`name`,`country`) VALUES ('admin','PL');
+INSERT INTO `users`(`name`,`country`) VALUES ('user','PL');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+web:
+  build: .
+  dockerfile: conf/Dockerfile.web
+  ports:
+    - "8000:80"
+  links:
+    - db
+  volumes:
+    - .:/var/www/html/
+
+db:
+  build: ./conf
+  dockerfile: Dockerfile.db
+  volumes:
+    - ./mysql:/etc/mysql/conf.d
+  environment:
+    MYSQL_ROOT_PASSWORD: root_password
+    MYSQL_DATABASE: wlm
+    MYSQL_USER: dbuser
+    MYSQL_PASSWORD: password


### PR DESCRIPTION
Hello! I wanted to have a look at this tool, so I added a setup to easily spin up a local development 
environment using Docker and docker-compose.

This setup includes:
- a Dockerfile based on php:5.6-apache to run the webserver
  (with some extensions installed)
- a Dockerfile based on mysql:5.5.49 for the database
  (bootstrapped with the tables/usrers fixtures)

Running `docker-compose up` will bring up a webserver
on http://localhost:8000/, with a default user admin/pass.

Also alter the tables.sql fixtures to add a column 'name'
instead of 'user_name' as it what is expected from login.php
Add some dummy fixtures for users.

Hope that helps :)
